### PR TITLE
Local network ip lookup

### DIFF
--- a/src/main/java/nsusbloader/com/net/NetworkSetupValidator.java
+++ b/src/main/java/nsusbloader/com/net/NetworkSetupValidator.java
@@ -124,6 +124,9 @@ public class NetworkSetupValidator {
             return;
         }
 
+        if (findIpLocally())
+            return;
+        
         if (findIpUsingHost("google.com"))
             return;
 
@@ -150,6 +153,29 @@ public class NetworkSetupValidator {
                     + " server (InetSocketAddress). Returned:\n\t"+e.getMessage(), EMsgType.INFO);
             return false;
         }
+    }
+
+    private boolean findIpLocally() throws InterruptedException {
+        try {
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface iface = interfaces.nextElement();
+                if (iface.isLoopback() || !iface.isUp()) continue;
+
+                Enumeration<InetAddress> addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    InetAddress addr = addresses.nextElement();
+                    if (addr instanceof Inet4Address && !addr.isLoopbackAddress()) {
+                        hostIP = addr.getHostAddress();
+                        logPrinter.print("NET: Host IP detected locally as: " + hostIP, EMsgType.PASS);
+                        return true;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            logPrinter.print("NET: Error scanning local adapters: " + e.getMessage(), EMsgType.INFO);
+        }
+        return false;
     }
 
     private String getAvaliableIpExamples(){

--- a/src/main/java/nsusbloader/com/net/NetworkSetupValidator.java
+++ b/src/main/java/nsusbloader/com/net/NetworkSetupValidator.java
@@ -155,7 +155,7 @@ public class NetworkSetupValidator {
         }
     }
 
-    private boolean findIpLocally() throws InterruptedException {
+    private boolean findIpLocally() throws InterruptedException{
         try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
@@ -172,7 +172,8 @@ public class NetworkSetupValidator {
                     }
                 }
             }
-        } catch (SocketException e) {
+        }
+        catch (SocketException e){
             logPrinter.print("NET: Error scanning local adapters: " + e.getMessage(), EMsgType.INFO);
         }
         return false;


### PR DESCRIPTION
I have systems that have no DNS, so I must configure ns-usbloader IP settings in 'Expert' mode. This patch fixes that, it allows local IP lookup with no DNS or Internet access needed.